### PR TITLE
Add support for `$.`-prefixed locale references, i.e. `$.Locale`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ go build ./cmd/tgotext
 
 ## Usage
 
-Assuming the build went well, `tgotext` currently only has one command: `parse`. It expects the path to a template file as an argument, and offers the `--object` flag to specify the name of the `Locale` object that is referenced in the template. That is, if you named your `Locale` object `Loc` and therefore use like `{{ .Loc.Get "Your text goes here!" }}` in a template file called `/tmp/my_template.tpl.html`, you would call:
+Assuming the build went well, `tgotext` currently only has one command: `parse`. It expects the path to a template file as an argument, and offers the `--object` flag to specify the name of the `Locale` object that is referenced in the template. That is, if you named your `Locale` object `Loc` and therefore use like `{{ .Loc.Get "Your text goes here!" }}` or `{{ $.Loc.Get "Your text goes here!" }}` in a template file called `/tmp/my_template.tpl.html`, you would call:
 
 ```bash
-tgotext parse /tmp/my_template.tpl.html --object Loc > /tmp/default.pot
+tgotext parse /tmp/my_template.tpl.html --object .Loc > /tmp/default.pot
+# Or for templates using the root context:
+tgotext parse /tmp/my_template.tpl.html --object $.Loc > /tmp/default.pot
 ```
 
 The tool doesn't write files directly, it only prints to `stdout` so you can redirect the output as you like.

--- a/cmd/tgotext/tgotext.go
+++ b/cmd/tgotext/tgotext.go
@@ -36,7 +36,7 @@ msgstr ""
 	cmdParse := &cobra.Command{
 		Use:   "parse [template file to parse]",
 		Short: "Parse a template file for translatable strings",
-		Long:  "The given template file is checked for all instances of \"{{ ." + objName + ".Get \"<text>\" }}\".",
+		Long:  "The given template file is checked for all instances of \"{{ " + objName + ".Get \"<text>\" }}\".",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			f, err := os.Open(args[0])
@@ -45,7 +45,7 @@ msgstr ""
 			}
 			defer f.Close()
 
-			re := regexp.MustCompile(`\{\{\s*.` + objName + `.Get "(.*)"\s*\}\}`)
+			re := regexp.MustCompile(`\{\{\s*` + regexp.QuoteMeta(objName) + `\.Get "(.*?)"\s*\}\}`)
 
 			fScanner := bufio.NewScanner(f)
 			fScanner.Split(bufio.ScanLines)
@@ -65,7 +65,7 @@ msgstr ""
 			}
 		},
 	}
-	cmdParse.Flags().StringVarP(&objName, "object", "o", objName, "The name of the Locale object used in the template (without dot prefix!)")
+	cmdParse.Flags().StringVarP(&objName, "object", "o", objName, "The name of the Locale object used in the template (e.g., 'Locale', '.Locale', '$.Locale')")
 	rootCmd.PersistentFlags().Bool("header", false, "Print POT header")
 	rootCmd.AddCommand(cmdParse)
 


### PR DESCRIPTION
This adds support for accessing locales that are nested, i.e. `$.Locale` (in `{{ $.Locale.Get "Markdown" }}`, see https://github.com/pojntfx/senbara/blob/main/senbara-forms/web/templates/activities_add.html#L35). Currently, these can't be extracted, but with the change it works fine:

```
pojntfx@fedora-42-Server:~/Projets/tgotext$ go run ./cmd/tgotext/tgotext.go parse ../senbara/senbara-forms/web/templates/activities_add.html --object '$.Locale'
#: activities_add.html:24
msgid "Name"
msgstr ""

#: activities_add.html:28
msgid "Date"
msgstr ""

#: activities_add.html:33
msgid "Description (optional)"
msgstr ""

#: activities_add.html:33
msgid "(you can use"
msgstr ""

#: activities_add.html:35
msgid "Markdown"
msgstr ""

#: activities_add.html:36
msgid ")"
msgstr ""

#: activities_add.html:42
msgid "Add an activity"
msgstr ""
```

The original behavior should also still work by just passing in `--object '.Locale'.