### PR TITLE
Add support for escaped strings and multiline/line breaks in template calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ go build ./cmd/tgotext
 
 ## Usage
 
-Assuming the build went well, `tgotext` currently only has one command: `parse`. It expects the path to a template file as an argument, and offers the `--object` flag to specify the name of the `Locale` object that is referenced in the template. That is, if you named your `Locale` object `Loc` and therefore use like `{{ .Loc.Get "Your text goes here!" }}` in a template file called `/tmp/my_template.tpl.html`, you would call:
+Assuming the build went well, `tgotext` currently only has one command: `parse`. It expects the path to a template file as an argument, and offers the `--object` flag to specify the name of the `Locale` object that is referenced in the template. That is, if you named your `Locale` object `Loc` and therefore use like `{{ .Loc.Get "Your text goes here!" }}` or `{{ $.Loc.Get "Your text goes here!" }}` in a template file called `/tmp/my_template.tpl.html`, you would call:
 
 ```bash
-tgotext parse /tmp/my_template.tpl.html --object Loc > /tmp/default.pot
+tgotext parse /tmp/my_template.tpl.html --object .Loc > /tmp/default.pot
+# Or for templates using the root context:
+tgotext parse /tmp/my_template.tpl.html --object $.Loc > /tmp/default.pot
 ```
 
 The tool doesn't write files directly, it only prints to `stdout` so you can redirect the output as you like.

--- a/cmd/tgotext/tgotext.go
+++ b/cmd/tgotext/tgotext.go
@@ -36,7 +36,7 @@ msgstr ""
 	cmdParse := &cobra.Command{
 		Use:   "parse [template file to parse]",
 		Short: "Parse a template file for translatable strings",
-		Long:  "The given template file is checked for all instances of \"{{ ." + objName + ".Get \"<text>\" }}\".",
+		Long:  "The given template file is checked for all instances of \"{{ " + objName + ".Get \"<text>\" }}\".",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			f, err := os.Open(args[0])
@@ -45,7 +45,7 @@ msgstr ""
 			}
 			defer f.Close()
 
-			re := regexp.MustCompile(`\{\{\s*.` + objName + `.Get "(.*)"\s*\}\}`)
+			re := regexp.MustCompile(`\{\{\s*` + regexp.QuoteMeta(objName) + `\.Get "(.*?)"\s*\}\}`)
 
 			fScanner := bufio.NewScanner(f)
 			fScanner.Split(bufio.ScanLines)
@@ -65,7 +65,7 @@ msgstr ""
 			}
 		},
 	}
-	cmdParse.Flags().StringVarP(&objName, "object", "o", objName, "The name of the Locale object used in the template (without dot prefix!)")
+	cmdParse.Flags().StringVarP(&objName, "object", "o", objName, "The name of the Locale object used in the template (e.g., 'Locale', '.Locale', '$.Locale')")
 	rootCmd.PersistentFlags().Bool("header", false, "Print POT header")
 	rootCmd.AddCommand(cmdParse)
 


### PR DESCRIPTION
Depends on #1 

This PR adds support for extracting strings that `gotext` correctly translates, but the current `main` branch doesn't extract. Some examples (note the line breaks):

```html
<h2>{{ $.Locale.Get "Edit %v %v" .Entry.FirstName .Entry.LastName }}</h2>

<h2>{{ $.Locale.Get "Edit \"%v\"" .Entry.Title }}</h2>

<input type="text" name="first_name" id="first_name" placeholder="{{
$.Locale.Get "Jean" }}" required autofocus />
```

With these changes, the parser can detect when it is inside of a template tag or not, and sum up the lines to add to the POT file properly. I've also change the regex so that escaped quotes in strings are handled correctly.